### PR TITLE
Fix: Add missing platform-specific source files and correct .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -181,7 +181,8 @@ _deps/
 # Output directories
 bin/
 lib/
-libs/
+# Note: libs/ contains source code, not build artifacts
+# Only ignore specific build output directories
 dist/
 release/
 debug/
@@ -258,7 +259,8 @@ massif.out.*
 cachegrind.out.*
 
 # Debugging
-core
+# Core dump files (but not our libs/core/ directory)
+/core
 core.*
 vgcore.*
 *.dmp

--- a/libs/core/src/platform/linux_utils.cpp
+++ b/libs/core/src/platform/linux_utils.cpp
@@ -1,0 +1,72 @@
+/**
+ * @file linux_utils.cpp
+ * @brief Linux-specific utility functions implementation
+ * 
+ * This file contains platform-specific implementations for Linux systems.
+ * It provides Linux-specific functionality that complements the cross-platform
+ * core utilities.
+ */
+
+#include <string>
+#include <vector>
+#include <fstream>
+
+namespace core {
+namespace platform {
+
+/**
+ * @brief Get Linux system information
+ * @return String containing system information
+ */
+std::string getSystemInfo() {
+    return "Linux System";
+}
+
+/**
+ * @brief Get Linux-specific temporary directory
+ * @return Path to temporary directory
+ */
+std::string getTempDirectory() {
+    const char* tmpdir = std::getenv("TMPDIR");
+    if (tmpdir) return std::string(tmpdir);
+    
+    const char* tmp = std::getenv("TMP");
+    if (tmp) return std::string(tmp);
+    
+    return "/tmp";
+}
+
+/**
+ * @brief Get Linux distribution information
+ * @return Distribution name and version
+ */
+std::string getLinuxDistribution() {
+    std::ifstream file("/etc/os-release");
+    if (file.is_open()) {
+        std::string line;
+        while (std::getline(file, line)) {
+            if (line.find("PRETTY_NAME=") == 0) {
+                return line.substr(12); // Remove "PRETTY_NAME="
+            }
+        }
+    }
+    return "Unknown Linux Distribution";
+}
+
+/**
+ * @brief Check if running in a container
+ * @return True if running in a container environment
+ */
+bool isRunningInContainer() {
+    std::ifstream file("/proc/1/cgroup");
+    if (file.is_open()) {
+        std::string content((std::istreambuf_iterator<char>(file)),
+                           std::istreambuf_iterator<char>());
+        return content.find("docker") != std::string::npos ||
+               content.find("lxc") != std::string::npos;
+    }
+    return false;
+}
+
+} // namespace platform
+} // namespace core

--- a/libs/core/src/platform/macos_utils.cpp
+++ b/libs/core/src/platform/macos_utils.cpp
@@ -1,0 +1,56 @@
+/**
+ * @file macos_utils.cpp
+ * @brief macOS-specific utility functions implementation
+ * 
+ * This file contains platform-specific implementations for macOS/Darwin systems.
+ * It provides macOS-specific functionality that complements the cross-platform
+ * core utilities.
+ */
+
+#include <string>
+#include <vector>
+
+namespace core {
+namespace platform {
+
+/**
+ * @brief Get macOS system information
+ * @return String containing system information
+ */
+std::string getSystemInfo() {
+    return "macOS/Darwin System";
+}
+
+/**
+ * @brief Get macOS-specific temporary directory
+ * @return Path to temporary directory
+ */
+std::string getTempDirectory() {
+    const char* tmpdir = std::getenv("TMPDIR");
+    return tmpdir ? std::string(tmpdir) : "/tmp";
+}
+
+/**
+ * @brief Check if running on Apple Silicon
+ * @return True if running on ARM64 architecture
+ */
+bool isAppleSilicon() {
+#ifdef __aarch64__
+    return true;
+#else
+    return false;
+#endif
+}
+
+/**
+ * @brief Get macOS version information
+ * @return Version string
+ */
+std::string getMacOSVersion() {
+    // This is a simplified implementation
+    // In a real application, you might use system calls to get actual version
+    return "macOS (version detection not implemented)";
+}
+
+} // namespace platform
+} // namespace core

--- a/libs/core/src/platform/windows_utils.cpp
+++ b/libs/core/src/platform/windows_utils.cpp
@@ -1,0 +1,94 @@
+/**
+ * @file windows_utils.cpp
+ * @brief Windows-specific utility functions implementation
+ * 
+ * This file contains platform-specific implementations for Windows systems.
+ * It provides Windows-specific functionality that complements the cross-platform
+ * core utilities.
+ */
+
+#ifdef _WIN32
+#include <windows.h>
+#endif
+
+#include <string>
+#include <vector>
+
+namespace core {
+namespace platform {
+
+/**
+ * @brief Get Windows system information
+ * @return String containing system information
+ */
+std::string getSystemInfo() {
+    return "Windows System";
+}
+
+/**
+ * @brief Get Windows-specific temporary directory
+ * @return Path to temporary directory
+ */
+std::string getTempDirectory() {
+#ifdef _WIN32
+    char tempPath[MAX_PATH];
+    DWORD result = GetTempPathA(MAX_PATH, tempPath);
+    if (result > 0 && result < MAX_PATH) {
+        return std::string(tempPath);
+    }
+#endif
+    
+    // Fallback to environment variables
+    const char* temp = std::getenv("TEMP");
+    if (temp) return std::string(temp);
+    
+    const char* tmp = std::getenv("TMP");
+    if (tmp) return std::string(tmp);
+    
+    return "C:\\temp";
+}
+
+/**
+ * @brief Get Windows version information
+ * @return Version string
+ */
+std::string getWindowsVersion() {
+#ifdef _WIN32
+    OSVERSIONINFOA osvi;
+    ZeroMemory(&osvi, sizeof(OSVERSIONINFOA));
+    osvi.dwOSVersionInfoSize = sizeof(OSVERSIONINFOA);
+    
+    // Note: GetVersionExA is deprecated, but used here for simplicity
+    // In production code, consider using VerifyVersionInfo or other methods
+    if (GetVersionExA(&osvi)) {
+        return "Windows " + std::to_string(osvi.dwMajorVersion) + 
+               "." + std::to_string(osvi.dwMinorVersion);
+    }
+#endif
+    return "Windows (version detection not available)";
+}
+
+/**
+ * @brief Check if running as administrator
+ * @return True if running with administrator privileges
+ */
+bool isRunningAsAdmin() {
+#ifdef _WIN32
+    BOOL isAdmin = FALSE;
+    PSID adminGroup = NULL;
+    
+    SID_IDENTIFIER_AUTHORITY ntAuthority = SECURITY_NT_AUTHORITY;
+    if (AllocateAndInitializeSid(&ntAuthority, 2, SECURITY_BUILTIN_DOMAIN_RID,
+                                DOMAIN_ALIAS_RID_ADMINS, 0, 0, 0, 0, 0, 0, &adminGroup)) {
+        CheckTokenMembership(NULL, adminGroup, &isAdmin);
+        FreeSid(adminGroup);
+    }
+    
+    return isAdmin == TRUE;
+#else
+    return false;
+#endif
+}
+
+} // namespace platform
+} // namespace core


### PR DESCRIPTION
- Add libs/core/src/platform/macos_utils.cpp for macOS-specific functionality
- Add libs/core/src/platform/linux_utils.cpp for Linux-specific functionality
- Add libs/core/src/platform/windows_utils.cpp for Windows-specific functionality
- Fix .gitignore to not ignore libs/ source directory (was too broad)
- Fix .gitignore core rule to only ignore core dump files, not libs/core/ directory

These platform-specific files are required by CMakeLists.txt and were missing, causing build failures. The .gitignore rules were incorrectly excluding important source code directories.